### PR TITLE
Allow use of resources with blank default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,4 +5,4 @@
 # Copyright (c) 2016, David Joos
 #
 
-include_recipe 'newrelic::server_monitor_agent'
+# Blank recipe to allow use of resources

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -4,6 +4,6 @@ describe 'newrelic::default' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
   it 'includes the server_monitor_agent recipe' do
-    expect(chef_run).to include_recipe('newrelic::server_monitor_agent')
+    expect(chef_run).to_not include_recipe('newrelic::server_monitor_agent')
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,16 +1,7 @@
 require 'spec_helper'
 
 describe 'newrelic::default' do
-  describe yumrepo('newrelic'), :if => os[:family] == 'redhat' do
-    it { is_expected.to exist }
-    it { is_expected.to be_enabled }
-  end
-
-  describe file('/etc/apt/sources.list.d/newrelic.list'), :if => %w[debian ubuntu].include?(os[:family]) do
-    it { is_expected.to be_file }
-  end
-
   describe package 'newrelic-sysmond' do
-    it { is_expected.to be_installed }
+    it { is_expected.to_not be_installed }
   end
 end


### PR DESCRIPTION
Make default recipe blank so that cookbook can be included to use resources only.